### PR TITLE
List external publications (blog posts, conferences etc.)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -220,6 +220,8 @@ compress_html:
   ignore:
     envs: development
 
+collections:
+  - external_publications
 
 # Defaults
 defaults:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,7 +1,7 @@
 main:
   - title: "Home"
     url: /
-  - title: "Tags"
-    url: /tags
   - title: "About"
     url: /about
+  - title: "Publications"
+    url: /publications

--- a/_external_publications/11-04-2019-e2e-load-testing.md
+++ b/_external_publications/11-04-2019-e2e-load-testing.md
@@ -1,0 +1,6 @@
+---
+name: End-to-end load testing Zalando’s production website
+external_url: https://jobs.zalando.com/tech/blog/end-to-end-load-testing-zalandos-production-website/
+category: Blog posts
+---
+This blog post sums up my work that contributed to a successful Black Friday 2018 at Zalando.

--- a/_external_publications/15-05-2018-selenium-meetup.md
+++ b/_external_publications/15-05-2018-selenium-meetup.md
@@ -1,0 +1,6 @@
+---
+name: Berlin Selenium Meetup, 15.05.2018
+external_url: https://www.meetup.com/Berlin-Selenium-Meetup/events/249668010/
+category: Conferences and meetups
+---
+I presented a lightning talk _Dealing with flaky tests - a short dive into the world of failure_ based on my own blog post [_Dealing with flaky tests_](/dealing-with-flaky-tests).

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -5,7 +5,7 @@ title: "About this blog"
 slug: about
 comments: false
 ---
-Oh, hey -- I'm Oliwia and this is my blog. I'm passionate about software quality and delivery. The idea of starting it was sparked by a one particular topic I wanted to write about. I will try to add some more posts in the near future. I have a cat.
+Hey, I'm Oliwia and this is my blog. I'm passionate about software quality and delivery. The idea of starting it was sparked by a one particular topic I wanted to write about. I will try to add some more posts in the near future. I have a cat.
 
 
 This blog is generated using [Jekyll](https://jekyllrb.com/) and hosted via [GitHub Pages](https://pages.github.com/). The theme I'm using is called [Minimal Mistakes](https://mmistakes.github.io/minimal-mistakes/).

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -1,0 +1,13 @@
+---
+layout: archive
+permalink: /publications/
+title: "My publications elsewhere"
+---
+
+## Blog Posts
+[_End-to-end load testing Zalando’s production website_](https://jobs.zalando.com/tech/blog/end-to-end-load-testing-zalandos-production-website/) is a blog post that sums up my work that contributed to a successful Black Friday 2018 at Zalando.
+
+## Conferences and meetups
+
+#### 15.05.2018, Berlin Selenium Meetup
+I presented a lightning talk _Dealing with flaky tests - a short dive into the world of failure_ based on my own blog post [_Dealing with flaky tests_](/dealing-with-flaky-tests). For more details see [the full agenda](https://www.meetup.com/Berlin-Selenium-Meetup/events/249668010/) of the meetup.

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -2,12 +2,21 @@
 layout: archive
 permalink: /publications/
 title: "My publications elsewhere"
+comments: false
 ---
 
-## Blog Posts
-[_End-to-end load testing Zalando’s production website_](https://jobs.zalando.com/tech/blog/end-to-end-load-testing-zalandos-production-website/) is a blog post that sums up my work that contributed to a successful Black Friday 2018 at Zalando.
+{% include group-by-array collection=site.external_publications field="category" %}
 
-## Conferences and meetups
-
-#### 15.05.2018, Berlin Selenium Meetup
-I presented a lightning talk _Dealing with flaky tests - a short dive into the world of failure_ based on my own blog post [_Dealing with flaky tests_](/dealing-with-flaky-tests). For more details see [the full agenda](https://www.meetup.com/Berlin-Selenium-Meetup/events/249668010/) of the meetup.
+{% for category in group_names %}
+  {% assign posts = group_items[forloop.index0] %}
+  <h2 id="{{ category }}" class="archive__subtitle">{{ category }}</h2>
+  {% for post in posts %}
+  <h2>
+    <a href="{{ post.external_url }}">
+      {{ post.name }}
+    </a>
+  </h2>
+  <p>{{ post.content }}</p>
+  {% endfor %}
+  <br>
+{% endfor %}

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -16,7 +16,7 @@ comments: false
       {{ post.name }}
     </a>
   </h2>
-  <p>{{ post.content }}</p>
+  <p>{{ post.content | markdownify }}</p>
   {% endfor %}
   <br>
 {% endfor %}

--- a/_posts/2018-01-28-dealing-with-flaky-tests.md
+++ b/_posts/2018-01-28-dealing-with-flaky-tests.md
@@ -7,8 +7,10 @@ tags: testing
 slug: dealing-with-flaky-tests
 comments: true
 header:
-  image: assets/images/tim-gouw-128115.jpg
+  overlay_image: assets/images/tim-gouw-128115.jpg
   og_image: assets/images/tim-gouw-128115.jpg
+  overlay_filter: 0.5
+  show_overlay_excerpt: false
 ---
 ## Embrace the failure
 I love failed tests, I really do. The sight of a red light on continuous integration system on Monday morning is my favorite way to start a week. Whenever I spot a failed test, I'm thrilled - mostly because it means there's something I'm going to learn. There's something that went wrong, something that got broken, or flaw that was hidden until now just resurfaced. And there's no best way to learn about it than from tests!

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -1,0 +1,29 @@
+/* system typefaces */
+$serif                        : Georgia, Times, serif !default;
+$sans-serif                   : -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI", "Helvetica Neue", "Lucida Grande", Arial, sans-serif !default;
+$monospace                    : Monaco, Consolas, "Lucida Console", monospace !default;
+
+/* sans serif typefaces */
+$sans-serif-narrow            : $sans-serif !default;
+$helvetica                    : Helvetica, "Helvetica Neue", Arial, sans-serif !default;
+
+/* serif typefaces */
+$georgia                      : Georgia, serif !default;
+$times                        : Times, serif !default;
+$bodoni                       : "Bodoni MT", serif !default;
+$calisto                      : "Calisto MT", serif !default;
+$garamond                     : Garamond, serif !default;
+
+$global-font-family           : $serif !default;
+$header-font-family           : $sans-serif !default;
+$caption-font-family          : $serif !default;
+
+/* type scale */
+$type-size-1                  : 2.441em !default;  // ~39.056px
+$type-size-2                  : 1.953em !default;  // ~31.248px
+$type-size-3                  : 1.563em !default;  // ~25.008px
+$type-size-4                  : 1.25em !default;   // ~20px
+$type-size-5                  : 1em !default;      // ~16px
+$type-size-6                  : 0.75em !default;   // ~12px
+$type-size-7                  : 0.6875em !default; // ~11px
+$type-size-8                  : 0.625em !default;  // ~10px


### PR DESCRIPTION
Use [Jekyll's collections](https://jekyllrb.com/docs/collections/) feature to group and list external publications.

Additionally:
- keep an explicit definition of scss (mainly for changing fonts)
- change main image in the blog post to an overlay (it will appear smaller now)
